### PR TITLE
Removed conversion of Borrower netid to first/last name.

### DIFF
--- a/ReadingRoomCheckout.php
+++ b/ReadingRoomCheckout.php
@@ -692,11 +692,11 @@ function booksOverdue ($user)
         $table->SetCellContent($row, 6, "<strong>Author</strong>");
 
         foreach ($results as $book) {
-            $sql = "select name from Statdir where netid = '".$book['Borrower']."'";
-            $results = simple_query($sql);
+            //$sql = "select name from Statdir where netid = '".$book['Borrower']."'";
+            //$results = simple_query($sql);
             $bookName = "bookCI_".$book['BookID'];
             $row = $table->AddRow();
-            $table->SetCellContent($row, 1, contact($user, $results[0]['name'], $book['Borrower'], $book['BookID']));
+            $table->SetCellContent($row, 1, contact($user, $book['Borrower'], $book['Borrower'], $book['BookID']));
             $table->SetCellContent($row, 2, $book['DateCheckedOut']);
             $table->SetCellContent($row, 3, $book['DateContacted']);
             if (!empty($book['ContactedID'])) {
@@ -747,10 +747,10 @@ function booksOut()
         $table->SetCellContent($row, 6, "<strong>Renew</strong>");
 
         foreach ($results as $book) {
-            $sql = "select name from Statdir where netid = '".$book['Borrower']."'";
-            $results = simple_query($sql);
+            //$sql = "select name from Statdir where netid = '".$book['Borrower']."'";
+            //$results = simple_query($sql);
             $bookName = "bookCI_".$book['BookID'];
-			$name = $results[0]['name'];
+            $name = $book['Borrower'];
 
             $row = $table->AddRow();
             $content = "<input name='{$bookName}' type='submit' value='Check In'>";


### PR DESCRIPTION
Per Service Now incident INC0431753.
The list of checked out and overdue items displays the first and last names in a 'Borrower' column. Internally, the ReadingRoom app uses ISU NetID as the canonical identification of the borrower. When these lists are generated the NetIDs are looked up in the `Statdb` table to obtain the first and last name of the borrower. When no NetID is found in the 'Borrower' column is blank. Previously, NetID was never shown. This update removes the `Statdb` table lookups and uses NetID for the 'Borrower' column.